### PR TITLE
:sparkles: Atoms/ProfileIconコンポーネントの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ CSS
 
 Atomic Designを用いたコンポーネント管理とする
 
+### Atoms
+
+- `<ProfileIcon />`
+
 ### Molecules
 
 - `<Member />`

--- a/public/default_icon.svg
+++ b/public/default_icon.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg12"
+   version="1.1"
+   style="overflow:visible"
+   viewBox="-250 -250 500 500"
+   height="2000px"
+   width="2000px">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <rect
+     id="rect2"
+     fill-opacity="0"
+     fill="rgb(0,0,0)"
+     height="500"
+     width="500"
+     y="-250"
+     x="-250" />
+  <svg
+     id="svg10"
+     version="1.1"
+     y="-250"
+     x="-250"
+     viewBox="-250 -250 500 500"
+     height="500"
+     width="500"
+     style="overflow:visible">
+    <g
+       style="fill:#ffffff;stroke-linejoin:round"
+       id="g8">
+      <path
+         style="fill:#0e0e0e;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0"
+         id="path4"
+         d="M 46.92444,-46.3218 A 46.924443,46.859024 0 0 1 0,0.53722 46.924443,46.859024 0 0 1 -46.92445,-46.3218 46.924443,46.859024 0 0 1 0,-93.18083 46.924443,46.859024 0 0 1 46.92444,-46.3218 Z" />
+      <path
+         style="fill:#0e0e0e;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0"
+         id="path6"
+         d="M 37.05078,9.2863 A 66.929623,66.837992 0 0 1 0,20.51677 66.929623,66.837992 0 0 1 -37.0625,9.28825 c -24.4251,4.76087 -42.74805,26.0934 -42.74805,51.85352 V 93.18083 H 79.81055 V 61.14177 C 79.81055,35.37756 61.4817,14.04266 37.05078,9.2863 Z" />
+    </g>
+  </svg>
+</svg>

--- a/src/components/atoms/ProfileIcon.tsx
+++ b/src/components/atoms/ProfileIcon.tsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+type Props = { image_path?: string };
+
+const DEFAULT_ICON = '/default_icon.svg';
+
+const Icon = styled.img`
+  width: 75px;
+  height: 75px;
+  border-radius: 50%;
+  background-color: #ffcccb;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  transition: transform 0.3s ease;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+`;
+
+const ProfileIcon: React.FC<Props> = ({ image_path = DEFAULT_ICON }) => {
+  return <Icon src={image_path} alt="profile" />;
+};
+
+ProfileIcon.propTypes = {
+  image_path: PropTypes.string.isRequired,
+};
+
+export default ProfileIcon;

--- a/src/components/atoms/ProfileIcon.tsx
+++ b/src/components/atoms/ProfileIcon.tsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-type Props = { image_path?: string };
+type Props = { width: number; height: number; image_path?: string };
 
 const DEFAULT_ICON = '/default_icon.svg';
 
-const Icon = styled.img`
-  width: 75px;
-  height: 75px;
+const Icon = styled.img<Props>`
+  width: ${(props) => props.width}px;
+  height: ${(props) => props.height}px;
   border-radius: 50%;
   background-color: #ffcccb;
   border: none;
@@ -23,12 +23,18 @@ const Icon = styled.img`
   }
 `;
 
-const ProfileIcon: React.FC<Props> = ({ image_path = DEFAULT_ICON }) => {
-  return <Icon src={image_path} alt="profile" />;
+const ProfileIcon: React.FC<Props> = ({
+  image_path = DEFAULT_ICON,
+  height,
+  width,
+}) => {
+  return <Icon src={image_path} alt="profile" height={height} width={width} />;
 };
 
 ProfileIcon.propTypes = {
-  image_path: PropTypes.string.isRequired,
+  image_path: PropTypes.string,
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
 };
 
 export default ProfileIcon;


### PR DESCRIPTION
### 概要
- [x]  [✨ Atoms/ProfileIconコンポーネントの作成](https://github.com/PenPeen/react_nmixx_Introduction/commit/2aa93a3030b89e7e1896859182e910c8ddc4f66b)

メンバー一覧画面でのアイコン表示用

<img width="92" alt="image" src="https://github.com/PenPeen/react_nmixx_Introduction/assets/87213337/d0dcdb69-9a91-4061-b88a-a2443f456815">
